### PR TITLE
Match dot files by glob

### DIFF
--- a/src/tasks/send-examples.js
+++ b/src/tasks/send-examples.js
@@ -60,7 +60,7 @@ module.exports = inherit(Base, {
             return vow.resolve();
         }
 
-        return vowNode.promisify(glob)(this.createGlobPattern(), { cwd: process.cwd(), nodir: true })
+        return vowNode.promisify(glob)(this.createGlobPattern(), { cwd: process.cwd(), nodir: true, dot: true })
             .then(function (files) {
                 if (o.examples) {
                     files = files.filter(function (file) {


### PR DESCRIPTION
It's needed since libs now generates files with `.tmp.*` prefix instead of `bundle-name.*`
